### PR TITLE
CI/CD の設定

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,68 @@ jobs:
 
       - name: Post coverage report
         if: github.event_name == 'pull_request'
-        uses: mi-kas/kover-report@v1
+        uses: actions/github-script@v7
         with:
-          path: build/reports/kover/report.xml
-          title: Coverage Report
-          update-comment: true
+          script: |
+            const fs = require('fs');
+            const xml = fs.readFileSync('build/reports/kover/report.xml', 'utf8');
+
+            const metrics = ['INSTRUCTION', 'BRANCH', 'LINE', 'METHOD', 'CLASS'];
+            const labels = {
+              INSTRUCTION: 'Instruction',
+              BRANCH: 'Branch',
+              LINE: 'Line',
+              METHOD: 'Method',
+              CLASS: 'Class'
+            };
+
+            // パッケージレベルの集計値（最後に出現するもの）を使用
+            const rows = [];
+            for (const metric of metrics) {
+              const regex = new RegExp(`<counter type="${metric}" missed="(\\d+)" covered="(\\d+)"/>`, 'g');
+              let match, lastMatch;
+              while ((match = regex.exec(xml)) !== null) {
+                lastMatch = match;
+              }
+              if (lastMatch) {
+                const missed = parseInt(lastMatch[1]);
+                const covered = parseInt(lastMatch[2]);
+                const total = missed + covered;
+                const pct = total > 0 ? ((covered / total) * 100).toFixed(1) : '0.0';
+                rows.push(`| ${labels[metric]} | ${covered} | ${missed} | ${total} | ${pct}% |`);
+              }
+            }
+
+            const body = [
+              '## Coverage Report',
+              '',
+              '| Metric | Covered | Missed | Total | Coverage |',
+              '|--------|---------|--------|-------|----------|',
+              ...rows,
+              '',
+              `_Generated from \`build/reports/kover/report.xml\`_`
+            ].join('\n');
+
+            // 既存コメントを検索して更新、なければ新規作成
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            const existing = comments.find(c => c.body.includes('## Coverage Report'));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body
+              });
+            }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,44 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build
+        run: ./gradlew build
+
+      - name: Test
+        run: ./gradlew test
+
+      - name: Generate coverage report
+        if: github.event_name == 'pull_request'
+        run: ./gradlew koverXmlReport
+
+      - name: Post coverage report
+        if: github.event_name == 'pull_request'
+        uses: mi-kas/kover-report@v1
+        with:
+          path: build/reports/kover/report.xml
+          title: Coverage Report
+          update-comment: true


### PR DESCRIPTION
## Summary
- GitHub Actions ワークフロー（`.github/workflows/build.yml`）を追加
- `push`（main）および `pull_request`（main）時にビルドとテストを自動実行
- PR 時は Kover でカバレッジレポートを生成し、各指標（Instruction/Branch/Line/Method/Class）の詳細テーブルを PR コメントに自動投稿

## Test plan
- [x] この PR 自体で GitHub Actions が動作し、ビルド・テストが通ること
- [x] カバレッジレポートが PR コメントに表示されること

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)