### PR TITLE
README の修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build and Test](https://github.com/msfukui/intellij-plugin-eof-mark/actions/workflows/build.yml/badge.svg)](https://github.com/msfukui/intellij-plugin-eof-mark/actions/workflows/build.yml)
 
-# EOF Mark
+# IntelliJ Plugin EOF Mark
 
 IntelliJ Platform 向けプラグインです。エディタで開いたファイルの末尾に `[EOF]` マーカーを表示します。
 
@@ -46,4 +46,8 @@ IntelliJ Platform 向けプラグインです。エディタで開いたファ�
 
 ## ライセンス
 
-MIT
+[MIT](https://opensource.org/licenses/MIT)
+
+## その他
+
+このプロダクトは [Claude Code](https://claude.com/claude-code) を使用して作成されています。


### PR DESCRIPTION
## Summary
- プラグイン名を「IntelliJ Plugin EOF Mark」に修正
- ライセンス（MIT）に正式サイトへのリンクを追加
- 「その他」の章を追加し、Claude Code を使用して作成されたことを明記

## Test plan
- [x] README の記載内容が正しいこと

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)