### PR TITLE
インストール手順のコマンドを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ IntelliJ Platform 向けプラグインです。エディタで開いたファ�
 
 現在は Marketplace 未公開です。ローカルビルドからインストールできます。
 
-1. `./gradlew build` を実行
+1. `./gradlew buildPlugin` を実行
 2. `build/distributions/` 配下の zip ファイルを取得
 3. IntelliJ IDEA の Settings > Plugins > ⚙ > Install Plugin from Disk... から zip を選択
 


### PR DESCRIPTION
## Summary
- インストール手順のコマンドを `./gradlew build` から `./gradlew buildPlugin` に修正
- `build` タスクでは `build/distributions/` に配布用 zip が生成されないため

## Test plan
- [x] `./gradlew buildPlugin` 実行後に `build/distributions/` に zip が生成されること

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)