### PR TITLE
release.yml で RELEASE_TOKEN を使用してブランチ保護をバイパス

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Get latest release tag
         id: latest_tag


### PR DESCRIPTION
## Summary

- リリースワークフローの checkout ステップで `RELEASE_TOKEN` (PAT) を使用するように変更
- これにより main ブランチへのバージョンコミット push 時にブランチ保護ルールをバイパスできる

## 事前準備 (手動)

1. Fine-grained PAT を作成（対象: このリポジトリ、権限: `Contents: Read and write`）
2. リポジトリの Settings → Secrets and variables → Actions → New repository secret で `RELEASE_TOKEN` として登録
3. Settings → Rules → Rulesets → "main" の Bypass list に "Repository admin" を追加

## Test plan

- [x] `RELEASE_TOKEN` シークレットが登録されていること
- [x] ルールセットに Repository admin のバイパスが設定されていること
- [x] `gh workflow run release` でリリースが正常に完了すること

## 関連
- #36 

🤖 Generated with [Claude Code](https://claude.com/claude-code)